### PR TITLE
Update link and add link to youtube recording

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,5 +219,5 @@ All other steps are explained in each use case.
   Meetup](https://www.meetup.com/fr-FR/PyData-Paris/events/259187805/):
   [talk](https://peopledoc.github.io/mlvtools-tutorial/talks/pyData/presentation.html)
 * [PyData Amsterdam - May
-  2019](https://pydata.org/amsterdam2019/schedule/presentation/32/):
-  [tutorial](https://peopledoc.github.io/mlvtools-tutorial/talks/workshop/presentation.html)
+  2019](https://pydata.org/amsterdam2019/schedule/presentation/32/how-to-easily-set-up-and-version-your-machine-learning-pipelines-using-dvc-and-mlv-tools/):
+  [tutorial slides](https://peopledoc.github.io/mlvtools-tutorial/talks/workshop/presentation.html) and [video](https://www.youtube.com/watch?v=rUTlqpcmiQw)


### PR DESCRIPTION
The https://pydata.org/amsterdam2019/schedule/presentation/32/ link gives an "Forbidden, You don't have permission to access this resource." error.
Also added link to the youtube video recording.